### PR TITLE
Retain .salesforce_w2l_lead on sibling form submit

### DIFF
--- a/salesforce.php
+++ b/salesforce.php
@@ -647,7 +647,7 @@ function salesforce_form_shortcode($atts) {
 		
 		if( $form_id != $form ){
 			$content = salesforce_form($options, $sidebar, null, $form);
-			return $content;
+			return '<div class="salesforce_w2l_lead">'.$content.'</div>';
 			
 		}
 	}


### PR DESCRIPTION
Fixes a bug where submitting a w2l form causes all other w2l forms on the
same page to be rendered without div.salesforce_w2l_lead wrapper.
