### PR TITLE
Added an option to add a subject for the user CC email on a per-form basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ readme.html
 license.txt
 
 /.DS_Store
+.idea/

--- a/lib/salesforce_admin.class.php
+++ b/lib/salesforce_admin.class.php
@@ -254,7 +254,7 @@ class Salesforce_Admin extends OV_Plugin_Admin {
 				w2l_sksort($newinputs,'pos',true);
 				$options['forms'][$form_id]['inputs'] = $newinputs; //TODO
 
-				foreach (array('form_name','source','returl','successmsg','captchaform','labellocation','submitbutton','requiredfieldstext','requiredfieldstextpos','type','org_id') as $option_name) {
+				foreach (array('form_name','source','returl','successmsg','captchaform','labellocation','submitbutton','requiredfieldstext','requiredfieldstextpos','type','org_id', 'cc_email_subject') as $option_name) {
 					if (isset($_POST[$option_name])) {
 						$options['forms'][$form_id][$option_name] = $_POST[$option_name];
 					}
@@ -692,6 +692,14 @@ class Salesforce_Admin extends OV_Plugin_Admin {
 									$content .= '<input type="text" name="requiredfieldstext" style="width:50%;" value="'.esc_html(stripslashes( salesforce_get_option('requiredfieldstext',$form_id,$options) )).'">';
 									$content .= '<br/><small>'.__('Overrides the default message for this form (leave blank to use the global setting).').'</small>';
 									$content .= '</p>';
+
+									/* Add a Subject line to the User email on a per-form basis */
+									$content .= '<p>';
+									$content .= '<label>' . __( 'User CC email subject:', 'salesforce' ) . '</label><br/>';
+									$content .= '<input type="text" name="cc_email_subject" style="width:50%;" value="' . esc_html( salesforce_get_option( 'cc_email_subject', $form_id, $options ) ) . '">';
+									$content .= '<br/><small>' . __( 'Subject of the email when sending out a copy to the user.(leave blank to use the global setting)' ) . '</small>';
+									$content .= '</p>';
+
 
 									$content .= '<p>';
 									$content .= '<label>'.__('Captcha:','salesforce').'</label><br/>';

--- a/salesforce.php
+++ b/salesforce.php
@@ -632,7 +632,11 @@ function salesforce_cc_user($post, $options, $form_id = 1){
 
 	$headers = 'From: '.$from_name.' <' . $from_email . ">\r\n";
 
-	$subject = str_replace('%BLOG_NAME%', get_bloginfo('name'), $options['subject']);
+	if (!empty($options['forms'][$form_id]['cc_email_subject'])) {
+		$subject = str_replace('%BLOG_NAME%', get_bloginfo('name'), $options['forms'][$form_id]['cc_email_subject']);
+	} else {
+		$subject = str_replace('%BLOG_NAME%', get_bloginfo('name'), $options['subject']);
+	}
 	if( empty($subject) ) $subject = __('Thank you for contacting','salesforce').' '.get_bloginfo('name');
 
 


### PR DESCRIPTION
Added an option to be able to store email subjects for each form individually.
If left blank, will simply take the General option (which, if empty, already uses the default).
