### PR TITLE
Support to post lead or case from 1 form

### DIFF
--- a/salesforce.php
+++ b/salesforce.php
@@ -629,7 +629,7 @@ function submit_salesforce_form( $post, $options ) {
 	}
 
 	// Do we need to change the URL we're submitting to?
-	$url = apply_filters( 'salesforce_w2l_api_url', $url, $form_type );
+	$url = apply_filters( 'salesforce_w2l_api_url', $url, $form_type, $post );
 
 	// Pre submit actions
 	do_action( 'salesforce_w2l_before_submit', $post, $form_id, $form_type );
@@ -819,7 +819,7 @@ function salesforce_cc_admin( $post, $options, $form_id = 1, $subject = '', $app
 	//print_r( $emails );
 
 	$message = apply_filters('salesforce_w2l_cc_admin_email_content', $message );
-	$subject = apply_filters('salesforce_w2l_cc_admin_email_subject', $subject, $form_type );
+	$subject = apply_filters('salesforce_w2l_cc_admin_email_subject', $subject, $form_type, $post );
 
 	if( WP_DEBUG )
 		error_log( 'salesforce_cc_admin:'.print_r( array($emails,$message,$subject),1 ) );


### PR DESCRIPTION
Hi there,

First of all, thank you for this useful plugin :-)

I'd like to support to post lead or case from a 1 form and to change email subject depending on post data.

For example,
My form has a select(picklist) which has 2 selects like `partnership inquiry` and `question`.
When the `partnership inquiry` is selected I'd like to post lead, in the latter case, I'd like to post case and change email subject as selected name.

My solution is that pass $post to `salesforce_w2l_api_url` and `salesforce_w2l_cc_admin_email_subject` and then define below code in my active theme's functions.php:
```
add_filter( 'salesforce_w2l_api_url', 'my_w2l_api_url', 10, 3 );

function my_w2l_api_url( $url, $form_type, $post ){
    if ($post['InquiryCategory__c'] == 'partnership inquiry') {
        return 'https://www.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8';
    } else {
        return 'https://www.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8';
    }
}

add_filter('salesforce_w2l_cc_admin_email_subject','salesforce_change_email_subject', 10, 3);

function salesforce_change_email_subject( $subject, $form_type, $post ){
    return $post['InquiryCategory__c'];
}
```

If you'd consider merging this pr it would be great.
Thanks!